### PR TITLE
Remove zip_release validation from manifest schema

### DIFF
--- a/rhfest/checks/manifest.py
+++ b/rhfest/checks/manifest.py
@@ -21,7 +21,6 @@ MANIFEST_SCHEMA = vol.Schema(
             vol.Length(min=1, max=2),
         ),
         vol.Optional("dependencies"): [vol.Match(PYPI_DEPENDENCY_REGEX)],
-        vol.Optional("zip_release"): bool,
         vol.Optional("zip_filename"): vol.All(str, vol.Match(r"^[a-z0-9_-]+\.zip$")),
     },
     required=True,
@@ -94,7 +93,7 @@ class ManifestCheck:
 
         # Start validation
         self._validate_schema(manifest_data)
-        self._validate_custom_rules(manifest_data)
+        # self._validate_custom_rules(manifest_data)  # noqa: ERA001
 
         if self.errors:
             for error in self.errors:


### PR DESCRIPTION
## Proposed change
<!--
    Describe the big picture of your changes here to communicate to the
    maintainers why we should accept this pull request. If it fixes a bug
    or resolves a feature request, be sure to link to that issue in the
    additional information section.
-->
After discussion it was decided that `zip_filename` is sufficient and that `zip_release` can be removed.

## Additional information
<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #

## Checklist
<!--
    Go over all the following points, and put an `x` in all the boxes that apply.
    If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] I have updated the documentation if needed.
- [ ] I have updated the tests if needed.
