### PR TITLE
feat: Add domain validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A reusable GitHub Action that validates `manifest.json` files for RotorHazard pl
   - 📁 Presence of `custom_plugins` folder
   - 📁 Presence of single plugin domain folder
   - 📄 Presence of `manifest.json` file
+  - 🔁 Plugin domain folder matches the `domain` in `manifest.json`
 - 🚨 GitHub Action annotations for validation errors
 - ⚠️ Warnings for missing required fields
 - 🐳 Docker image for local testing (manual or pre-commit)

--- a/rhfest/checks/manifest.py
+++ b/rhfest/checks/manifest.py
@@ -73,6 +73,20 @@ class ManifestCheck:
         except vol.Invalid as e:
             self._add_error(e.path, e.msg)
 
+    def _validate_domain_matches_folder(self, manifest_data: dict) -> None:
+        """Validate that the manifest domain matches its parent folder name."""
+        manifest_domain = manifest_data.get("domain")
+        if not isinstance(manifest_domain, str):
+            return
+
+        folder_domain = self.manifest_file.parent.name
+        if manifest_domain != folder_domain:
+            self._add_error(
+                ["domain"],
+                f"Domain mismatch: Folder '{folder_domain}' vs Manifest "
+                f"'{manifest_domain}'",
+            )
+
     def _validate_custom_rules(self, manifest_data: dict) -> None:
         """Perform custom validation rules.
 
@@ -102,6 +116,7 @@ class ManifestCheck:
 
         # Start validation
         self._validate_schema(manifest_data)
+        self._validate_domain_matches_folder(manifest_data)
         # self._validate_custom_rules(manifest_data)  # noqa: ERA001
 
         if self.errors:


### PR DESCRIPTION
## Summary

Add validation to ensure the plugin domain folder name matches the `domain` defined in `manifest.json`.

## Changes

- Compare the parent plugin folder name with the manifest `domain`
- Report a clear GitHub Actions error when they differ
- Document the new validation rule in the README

## Motivation

Previously, RHFest validated the plugin directory structure and the format of the manifest domain independently, but did not verify that both values matched. This allowed invalid repositories to pass RHFest and fail later during community plugin metadata generation.